### PR TITLE
Hide out.mp4 before repacked

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,11 @@ async function processVideo(file) {
 
   // Apply obfuscation
 
-  // repack frames
-  const command2 = `${__dirname}/node_modules/ffmpeg-static/ffmpeg -y -start_number 0 -i 'frames/out%3d.jpg' out.mp4`;
+  // repack frames (hide the file until repacking is done)
+  const command2 = `${__dirname}/node_modules/ffmpeg-static/ffmpeg -y -start_number 0 -i 'frames/out%03d.jpg' .out.mp4`;
   const response2 = await exec(command2);
+
+  // Make the file visible on Unix-based systems
+  await exec(`mv .out.mp4 out.mp4`);
   console.log(response2);
 }

--- a/src/common/processVideo.js
+++ b/src/common/processVideo.js
@@ -26,9 +26,11 @@ async function unpackVideoToFrames(file, dir="frames") {
 
 async function packVideoFromFrames(dir="frames") {
   try {
-    const command2 = `${__dirname}/../../node_modules/ffmpeg-static/ffmpeg -y -start_number 0 -i '${dir}/out%3d.jpg' out.mp4`;
+    const command2 = `${__dirname}/../../node_modules/ffmpeg-static/ffmpeg -y -start_number 0 -i '${dir}/out%03d.jpg' .out.mp4`;
     const response2 = await exec(command2);
     console.log(response2);
+
+    await exec(`mv .out.mp4 out.mp4`);
     return true;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
Just a quick change that hides `out.mp4` on unix-like systems until the file is fully repacked. Also fixes a repacking issue I had due to `/out%3d.jpg` being used instead of `/out%03d.jpg`.