### PR TITLE
Updating the SCSS for when users prefer a specific color scheme.

### DIFF
--- a/src/common/Footer.scss
+++ b/src/common/Footer.scss
@@ -1,24 +1,43 @@
-.footer{
-  border: 2px solid black;
-  box-shadow: 4px 4px 0px black;
+@media (prefers-color-scheme: dark) {
+  .footer {
+    border: 2px solid white;
+    box-shadow: 4px 4px 0px white;
+    &__list {
+      &-item {
+        border-bottom: 2px solid white;
+      }
+    }
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .footer {
+    border: 2px solid #222;
+    box-shadow: 4px 4px 0px #222;
+    &__list {
+      &-item {
+        border-bottom: 2px solid #222;
+      }
+    }
+  }
+}
+
+.footer {
   padding: 0.5rem;
   margin-top: 2rem;
-  
-  &__list{
-    display:flex;
+
+  &__list {
+    display: flex;
     list-style: none;
     justify-content: space-between;
 
-    &-section{
+    &-section {
       display: flex;
-    
     }
 
-    &-item{
-      border-bottom:2px solid black;
-
-      &:not(:last-child){
-        margin-right:0.5rem;
+    &-item {
+      &:not(:last-child) {
+        margin-right: 0.5rem;
       }
     }
   }

--- a/src/common/Header.scss
+++ b/src/common/Header.scss
@@ -1,11 +1,23 @@
-.header{
+@media (prefers-color-scheme: dark) {
+  .header {
+    border: 2px solid white;
+    box-shadow: 4px 4px 0px white;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .header {
+    border: 2px solid #333;
+    box-shadow: 4px 4px 0px #333;
+  }
+}
+
+.header {
   display: flex;
   flex-direction: column;
   text-align: center;
   justify-content: center;
   align-items: center;
-  height:6rem;
-  border: 2px solid black;
+  height: 6rem;
   margin-bottom: 2rem;
-  box-shadow: 4px 4px 0px black;
 }

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -1,44 +1,89 @@
-*, *::before, *::after{
-  margin:0;
-  padding:0;
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
   box-sizing: border-box;
 }
 
-html{
+html {
   font-size: 16px;
 }
 
-body{
+body {
   line-height: 1.4;
   font-family: Arial, Helvetica, sans-serif;
 }
 
+@media (prefers-color-scheme: dark) {
+  html {
+    background-color: #222;
+    color: white;
+  }
 
+  .main {
+    &-section {
+      border: 1px solid white;
+    }
+  }
+  canvas {
+    border: 1px solid white;
+  }
 
-#app{
-  padding: 1rem;
-  height:100%;
-
+  .button {
+    background-color: #222;
+    color: white;
+    border: 1px solid white;
+    box-shadow: 2px 2px 0px white;
+  }
 }
 
-.main{
-  display:grid;
+@media (prefers-color-scheme: light) {
+  html {
+    background-color: white;
+    color: #222;
+  }
+
+  .main {
+    &-section {
+      border: 1px solid black;
+    }
+  }
+
+  canvas {
+    border: 1px solid black;
+  }
+
+  .button {
+    background-color: white;
+    color: #222;
+    border: 1px solid #222;
+    box-shadow: 2px 2px 0px #222;
+  }
+}
+
+#app {
+  padding: 1rem;
+  height: 100%;
+}
+
+.main {
+  display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-column-gap: 0.5rem;
 
-  &-section{
-    border: 1px solid black;
+  &-section {
     padding: 0.5rem;
-    height:auto;
+    height: auto;
 
-    &__title{
+    &__title {
       text-align: center;
     }
 
-    &__content{
-      width:100%;
-      height:200px;
-      max-height:100%;
+    &__content {
+      width: 100%;
+      height: 200px;
+      max-height: 100%;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -47,24 +92,21 @@ body{
   }
 }
 
-canvas{
-  border: 1px solid black;
+canvas {
   height: 100%;
-  width:100%;
-}
-
-#main-canvas-container{
   width: 100%;
-  height:100%;
 }
 
-.button{
-  padding:0.5rem 1rem;
+#main-canvas-container {
+  width: 100%;
+  height: 100%;
+}
+
+.button {
+  padding: 0.5rem 1rem;
   font-size: 1.2rem;
-  border: 1px solid black;
-  box-shadow: 2px 2px 0px black;
 }
 
-input{
-  display:block;
+input {
+  display: block;
 }


### PR DESCRIPTION
I changed the SCSS for users who prefer a specific color scheme on their devices. Working on macOS, I ran `yarn dev` and was presented with this screen, where I prefer the Dark macOS color scheme:

![Screen Shot 2020-06-03 at 10 46 40 AM](https://user-images.githubusercontent.com/1036984/83664911-47669400-a590-11ea-8b6d-be8bc7d894e3.png)

After changes to Header, Footer and Index SCSS, the text and boxes follow what the user preferences are for Light/Dark making it much easier to read:

![Screen Shot 2020-06-03 at 10 47 08 AM](https://user-images.githubusercontent.com/1036984/83665024-74b34200-a590-11ea-888f-0bdb41b56c9b.png)
![Screen Shot 2020-06-03 at 10 46 55 AM](https://user-images.githubusercontent.com/1036984/83665029-75e46f00-a590-11ea-9aa3-75ef1acd959d.png)
