### PR TITLE
Fits image to canvas container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ thumbs.db
 .idea/
 frames/
 out.mp4
+out-frames/
+
+IMG_9199.mp4

--- a/src/common/processVideo.js
+++ b/src/common/processVideo.js
@@ -28,11 +28,10 @@ async function unpackVideoToFrames(file, dir = "frames") {
   }
 }
 
-async function packVideoFromFrames(dir = "frames") {
+async function packVideoFromFrames(dir = "out-frames") {
   try {
     const command2 = `${__dirname}/../../node_modules/ffmpeg-static/ffmpeg -y -start_number 0 -i '${dir}/out%03d.jpg' .out.mp4`;
     const response2 = await exec(command2);
-    console.log(response2);
     await exec(`mv .out.mp4 out.mp4`);
     return {
       path: 'out.mp4'

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,7 +4,8 @@ import {
   app,
   BrowserWindow,
   dialog,
-  ipcMain
+  ipcMain,
+  nativeImage
 } from 'electron'
 import {
   processVideo,
@@ -15,6 +16,8 @@ import * as path from 'path'
 import {
   format as formatUrl
 } from 'url'
+import fs from 'fs';
+
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
@@ -108,9 +111,20 @@ app.on('ready', () => {
     } catch (error) {
       event.reply('PROCESS_VIDEO_ERR', 'ERR OCCURRED!');
     }
-
   })
 
+  ipcMain.on('SAVE_FILE', async (event, arg) => {
+    const results = await packVideoFromFrames(arg);
+  });
 
 
+  ipcMain.on('NEW_FRAME', async (event, arg) => {
+    const img = nativeImage.createFromDataURL(arg.imgb64);
+    if (!fs.existsSync('out-frames')) {
+      fs.mkdirSync('out-frames');
+    }
+    // TODO Promisfy writeFile?
+    // TODO JPEG Quality?
+    fs.writeFileSync(`out-frames/out${arg.frameNum}.jpg`, img.toJPEG(100), () => {});
+  });
 })

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -116,9 +116,8 @@ class App {
       const image = nativeImage.createFromPath(frame);
       let img = await p.loadImagePromise(image.toDataURL());
       
-      p.canvas.width = img.width;
-      p.canvas.height = img.height;
-
+      p.resizeCanvas(img.width, img.height);
+      
       img.loadPixels();
       const segmentation = await this.bodyPix.segmentMultiPersonParts(img.canvas, {maxDetections:100});
       p.image(img, 0, 0);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -81,12 +81,13 @@ class App {
    * @param {*} p
    */
   sketch(p) {
+    const parentContainer = document.querySelector("#main-canvas-container");
+    const w = parentContainer.clientWidth;
+    const h = parentContainer.clientHeight;
     p.setup = () => {
-      const parentContainer = document.querySelector("#main-canvas-container");
-      const w = parentContainer.clientWidth;
-      const h = parentContainer.clientHeight;
+      
       // TODO: deal with canvas size
-      p.createCanvas(640, 360);
+      p.createCanvas(w, h);
     };
 
     p.loadImagePromise = (path) => {
@@ -101,21 +102,23 @@ class App {
     p.processFrame = async (frame) => {
       const image = nativeImage.createFromPath(frame);
       let img = await p.loadImagePromise(image.toDataURL());
+      img.resize(w,h);
       img.loadPixels();
       const segmentation = await this.bodyPix.segmentMultiPersonParts(img.canvas);
-      p.image(img, 0, 0);
+      p.image(img, 0, 0, w,h);
       console.log(segmentation);
       for (let i = 0; i < segmentation.length; i++) {
         let seg = segmentation[i];
-        for (let x = 0; x < img.width; x += 10) {
-          for (let y = 0; y < img.height; y += 10) {
+        const rectSize = 4;
+        for (let x = 0; x < img.width; x += rectSize) {
+          for (let y = 0; y < img.height; y += rectSize) {
             let index = x + y * img.width;
             if (seg.data[index] == 0 || seg.data[index] == 1) {
               p.fill(255, 0, 255);
-              p.rect(x, y, 10, 10);
+              p.rect(x, y, rectSize, rectSize);
             } else if (seg.data[index] > 1) {
               p.fill(0, 255, 0);
-              p.rect(x, y, 10, 10);
+              p.rect(x, y, rectSize, rectSize);
             }
           }
         }
@@ -186,10 +189,9 @@ class App {
 // main app
 window.addEventListener("DOMContentLoaded", async () => {
   const bodyPix = await bp.load({
-    architecture: "MobileNetV1",
+    architecture: 'ResNet50',
     outputStride: 16,
-    multiplier: 0.75,
-    quantBytes: 2,
+    quantBytes: 2
   });
 
   const app = new App(bodyPix);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -148,11 +148,19 @@ class App {
         frameNum: p.nf(p.frameNum, 3, 0)
       }
 
+      // change the canvas size to match the image size
+      
+      canvas.width = img.width  // * (parentContainer.clientWidth / p.canvas.elt.width);
+      canvas.height = img.height // * (parentContainer.clientHeight / p.canvas.elt.height);
+
       // render to the preview canvas
-      var hRatio = canvas.width / p.canvas.elt.width    ;
-      var vRatio = canvas.height / p.canvas.elt.height  ;
+      var hRatio = parentContainer.clientWidth / p.canvas.elt.width    ;
+      var vRatio = parentContainer.clientHeight / p.canvas.elt.height  ;
       var ratio  = Math.min ( hRatio, vRatio );
-      ctx.drawImage(p.canvas.elt, 0,0, p.canvas.elt.width, p.canvas.elt.height, 0,0,p.canvas.elt.width*ratio, p.canvas.elt.height*ratio);
+      canvas.width = (canvas.width * ratio);
+      canvas.height = (canvas.height * ratio);
+      // ctx.drawImage(p.canvas.elt, 0,0, p.canvas.elt.width, p.canvas.elt.height, 0,0,p.canvas.elt.width*ratio, p.canvas.elt.height*ratio);
+      ctx.drawImage(p.canvas.elt, 0,0, p.canvas.elt.width, p.canvas.elt.height, 0,0, canvas.width, canvas.height);
       
       // send the message to the main
       ipcRenderer.send("NEW_FRAME", msg);
@@ -177,7 +185,7 @@ class App {
         ${Header()}
         <main class="main">
           <section class="main-section">
-            <h2 class="main-section__title">Add your video</h2>
+            <h2 class="main-section__title">1. Add your video</h2>
             <div class="main-section__content">
               <button
                 onclick=${this.handleFileUpload.bind(this)}
@@ -192,7 +200,7 @@ class App {
             </div>
           </section>
           <section class="main-section">
-            <h2 class="main-section__title">Blur the faces</h2>
+            <h2 class="main-section__title">2. Video Preview</h2>
             <div class="main-section__content">
               <div id="main-canvas-container">
                 <canvas id="main-canvas"></canvas>
@@ -202,7 +210,7 @@ class App {
             </div>
           </section>
           <section class="main-section">
-            <h2 class="main-section__title">Download video</h2>
+            <h2 class="main-section__title">3. Download video</h2>
             <div class="main-section__content">
               <p>status: <span>${this.status}</span></p>
               <button

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -26,9 +26,9 @@ body {
       border: 1px solid white;
     }
   }
-  canvas {
-    border: 1px solid white;
-  }
+  // canvas {
+  //   border: 1px solid white;
+  // }
 
   .button {
     background-color: #222;
@@ -50,9 +50,9 @@ body {
     }
   }
 
-  canvas {
-    border: 1px solid black;
-  }
+  // canvas {
+  //   border: 1px solid black;
+  // }
 
   .button {
     background-color: white;
@@ -94,21 +94,26 @@ body {
 
 
 #main-canvas-container {
-  width: 320px;
-  height: 180px;
+  min-width: 320px;
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid white;
 }
-#main-canvas{
-  width:100%;
-  height:100%;
-}
+
+// #main-canvas{
+//   width:100%;
+//   height:100%;
+// }
 
 #hidden-canvas-container{
   display:none; 
 }
-#hidden-canvas{
-  width:640px;
-  height:360px;
-}
+// #hidden-canvas{
+//   width:640px;
+//   height:360px;
+// }
 
 .button {
   padding: 0.5rem 1rem;

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -92,14 +92,22 @@ body {
   }
 }
 
-canvas {
-  height: 100%;
-  width: 100%;
-}
 
 #main-canvas-container {
-  width: 100%;
-  height: 100%;
+  width: 320px;
+  height: 180px;
+}
+#main-canvas{
+  width:100%;
+  height:100%;
+}
+
+#hidden-canvas-container{
+  display:none; 
+}
+#hidden-canvas{
+  width:640px;
+  height:360px;
 }
 
 .button {


### PR DESCRIPTION
## Description

<s>This PR updates the current `processFrame()` function to use the `img.resize()` function in p5 to resize the incoming image to match that of the canvas container to fit in the given space.</s>

This PR approaches fitting a video preview into the canvas area by doing the following:
1. The incoming image sets the p5 canvas size.
2. the image segmentation occurs on a canvas that is set to `display:none`
3. the p5 canvas is drawn to the video preview area using another canvas element using `ctx.drawImage()` 
4. The video preview area is scaled to fit the preview area.

Additionally, this PR switches to the use of the `resnet50` model for higher accuracy on the bodypix results.

## Potential problems

<s>A better approach might be to apply the segmentation on the full size image, then resize for rendering purposes only -- TBD</s> -- resolved with using an off-screen canvas and showing an image preview in the video preview area.

## Updates

* My plan is to use an offscreen canvas for the video segmentation and a smaller canvas for the preview.  ==> done.
