### PR TITLE
adds rimraf to remove files in /frames & /out-frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ffmpeg-static": "^4.2.2",
     "nanohtml": "^1.9.1",
     "p5": "^1.0.0",
+    "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {

--- a/src/common/processVideo.js
+++ b/src/common/processVideo.js
@@ -1,7 +1,10 @@
 const ffmpeg = require("ffmpeg-static");
+const path = require('path');
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 const fs = require("fs");
+// to remove files from frames and out-frames
+const rimraf = require('rimraf');
 
 // const shellescape = require('any-shell-escape');
 // processVideo('test/Crowd-6582.mp4');
@@ -11,6 +14,14 @@ async function unpackVideoToFrames(file, dir = "frames") {
     // Make the directory
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir);
+    }
+
+    // clean the folder bef
+
+    rimraf.sync(`./${dir}/*`);
+
+    if (fs.existsSync('out-frames')) {
+      rimraf.sync(`./out-frames/*`);
     }
 
     // unpack frames

--- a/yarn.lock
+++ b/yarn.lock
@@ -6391,6 +6391,13 @@ rimraf@2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
## Description
This PR cleans up the `/frames` and `/out-frames` directories to ensure that each video doesn't blend with other previously processed video frames. 